### PR TITLE
Proxying to https correctly.

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -130,7 +130,7 @@ var getHandler = exports.getHandler = function(options) {
       return;
     } else {
       // Actual request. First, extract the desired URL from the request:
-      var full_url, host, hostname, port, path, match;
+      var full_url, host, hostname, port, path, match, isHttps;
       match = req.url.match(/^\/?(?:(https?:)?\/\/)?(([^\/?]+?)(?::(\d{0,5})(?=[\/?]|$))?)([\/?][\S\s]*|$)/i);
       //                            ^^^^^^^          ^^^^^^^^      ^^^^^^^                ^^^^^^^^^^^^
       //                          1:protocol       3:hostname     4:port                 5:path + query string
@@ -164,10 +164,11 @@ var getHandler = exports.getHandler = function(options) {
         return;
       } else {
         full_url = match[0].substr(1);
+        isHttps = (match[1] && match[1].toLowerCase()) === 'https:';
         host = match[2];
         hostname = match[3];
         // Read port from input:  :<port>  /  443 if https  /  80 by default
-        port = match[4] ? +match[4] : (match[1] && match[1].toLowerCase() === 'https:' ? 443 : 80);
+        port = match[4] ? +match[4] : (isHttps ? 443 : 80);
         path = match[5];
 
         if (!match[1]) {
@@ -187,7 +188,8 @@ var getHandler = exports.getHandler = function(options) {
 
       proxyRequest(req, res, proxy, full_url, {
         host: hostname,
-        port: port
+        port: port,
+        https: isHttps
       });
     }
   };


### PR DESCRIPTION
While working with https://secure.gravatar.com/xmlrpc I discovered that the proxy request was using http even when it was proxying to an https port / url.  This is because we didn't pass the https parameter through in the proxyRequest method.

This problem can be seen with the following code (assuming you're running cors-anywhere on 48080 on localhost).

``` javascript
var str = '<?xml version="1.0"?>\
<methodCall>\
    <methodName>grav.test</methodName>\
    <params>\
        <param>\
            <value>\
            <struct>\
                <member>\
                    <name>password</name><value><string>notMyRealPassword</string></value>\
                </member>\
            </struct>\
            </value>\
        </param>\
    </params>\
</methodCall>';
var xhr = new XMLHttpRequest();
var host = "http://localhost:48080"; // "https://cors-anywhere.herokuapp.com"
xhr.open('POST', host + '/https://secure.gravatar.com/xmlrpc?user=2a10f3086f0a55dcb3e05acdd9111a4f');
xhr.setRequestHeader('x-requested-with', 'my-code');
```

Before this change, I would receive a warning message 

```
400 Bad Request : The plain HTTP request was sent to HTTPS port
```

After the change, I get the expected XML back saying (since I passed the incorrect password) 

``` xml
<?xml version="1.0"?>
    <methodResponse>
       <fault>
          <value>
             <struct>
                <member>
                   <name>faultCode</name>
                   <value><int>-9</int></value>
                </member>
                <member>
                   <name>faultString</name>
                   <value><string>invalid or missing authentication information</string></value>
               </member>
            </struct>
         </value>
      </fault>
</methodResponse>
```
