### PR TITLE
Compatible with HTTP basic auth.

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -51,7 +51,12 @@ function isValidHostName(hostname) {
  * @param request {ServerRequest}
  */
 function withCORS(headers, request) {
-  headers['access-control-allow-origin'] = '*';
+  if (request.headers['origin']) {
+    headers['access-control-allow-origin'] = request.headers['origin'];
+  } else {
+    headers['access-control-allow-origin'] = '*';
+  }
+  headers['access-control-allow-credentials'] = 'true';
   if (request.headers['access-control-request-method']) {
     headers['access-control-allow-methods'] = request.headers['access-control-request-method'];
     delete request.headers['access-control-request-method'];


### PR DESCRIPTION
If you want to use HTTP basic auth via CORS, you can't have the wildcard for "access-control-allow-origin" and you must set "access-control-allow-credentials" to "true".
