### PR TITLE
ability to use proxy handler in independent way (attach to express for example)

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -291,9 +291,8 @@ var getHandler = exports.getHandler = function(options, proxy) {
   };
 };
 
-// Create server with default and given values
-// Creator still needs to call .listen()
-exports.createServer = function createServer(options) {
+// Create handler with default and given values
+var createHandler = exports.createHandler = function (options) {
   if (!options) options = {};
 
   // Default options:
@@ -308,7 +307,7 @@ exports.createServer = function createServer(options) {
   }
 
   var proxy = httpProxy.createServer(httpProxyOptions);
-  var server = http.createServer(getHandler(options, proxy));
+  var handler = getHandler(options, proxy);
 
   // When the server fails, just show a 404 instead of Internal server error
   proxy.on('error', function(err, req, res) {
@@ -323,5 +322,12 @@ exports.createServer = function createServer(options) {
   });
   proxy.on('proxyRes', onProxyResponse);
 
+  return handler;
+};
+
+// Create server with default and given values
+// Creator still needs to call .listen()
+exports.createServer = function createServer(options) {
+  var server = http.createServer(createHandler(options));
   return server;
 };


### PR DESCRIPTION
I want to use this proxy as express middleware/handler (mapped to some mount path). Header "x-cors-anywhere-url" added to simplify obtaining URL in this case.