### PR TITLE
Freezing EventEmitter major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "main": "./lib/cors-anywhere.js",
   "dependencies": {
-    "http-proxy": "1.3.0"
+    "http-proxy": "1.3.0",
+    "eventemitter3": "0.x.x"
   },
   "devDependencies": {
       "webkit-devtools-agent": "~0.2.1"


### PR DESCRIPTION
http-proxy 1.3.0 does not define an explicit EventEmitter version in its dependencies. This is only done since version 1.7.2.

Release 1.0.0 of EventEmitter introduces breaking changes (https://github.com/primus/eventemitter3/releases).

