### PR TITLE
Specifically allow origin from request header instead of using *

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -50,7 +50,8 @@ function isValidHostName(hostname) {
  * @param request {ServerRequest}
  */
 function withCORS(headers, request) {
-  headers['access-control-allow-origin'] = '*';
+  headers['access-control-allow-origin'] = request.headers.origin;
+  headers['Access-Control-Allow-Credentials'] = 'true';
   if (request.headers['access-control-request-method']) {
     headers['access-control-allow-methods'] = request.headers['access-control-request-method'];
     delete request.headers['access-control-request-method'];


### PR DESCRIPTION
+ And allow credentials.

I had to make these changes to make this work. Both Chrome and Firefox were complaining that using '*' is too permissive or something. Idk I think this cross origin stuff is important but the implementation is kinda screwed up and I can't make sense of it.