### PR TITLE
Add https://cors-anywhere.now.sh to "Live examples" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Request examples:
 Live examples:
 
 * https://cors-anywhere.herokuapp.com/
+* https://cors-anywhere.now.sh/
 * https://robwu.nl/cors-anywhere.html - This demo shows how to use the API.
 
 ## Documentation


### PR DESCRIPTION
Hello. I have deployed your CORS proxy to [Now](https://now.sh).

If you would like, feel free to merge this to add it to the listing in the README!

Have a great day 🍻  !