### PR TITLE
Add support for NODE_TLS_REJECT_UNAUTHORIZED

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -386,6 +386,7 @@ exports.createServer = function createServer(options) {
   // Default options:
   var httpProxyOptions = {
     xfwd: true,            // Append X-Forwarded-* headers
+    secure: process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0',
   };
   // Allow user to override defaults and add own options
   if (options.httpProxyOptions) {


### PR DESCRIPTION
This adds support for disabling the certificate validation checks via the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable.

Supersedes #120.
Fixes #71.