### PR TITLE
Handle same host requests

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -333,7 +333,9 @@ function getHandler(options, proxy) {
       return;
     }
 
-    var origin = req.headers.origin || '';
+    var origin = req.headers.origin || req.headers.referer || '';
+    origin = origin.replace(/^(https?:\/\/[^\/]*)(\/.*)?$/, '$1'); // Only keep the host part of the origin/referer
+
     if (corsAnywhere.originBlacklist.indexOf(origin) >= 0) {
       res.writeHead(403, 'Forbidden', cors_headers);
       res.end('The origin "' + origin + '" was blacklisted by the operator of this proxy.');

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ var cors_proxy = require('./lib/cors-anywhere');
 cors_proxy.createServer({
   originBlacklist: originBlacklist,
   originWhitelist: originWhitelist,
-  requireHeader: ['origin', 'x-requested-with'],
+  requireHeader: ['origin', 'x-requested-with', 'referer'],
   checkRateLimit: checkRateLimit,
   removeHeaders: [
     'cookie',


### PR DESCRIPTION
This adds support for the Referrer header since the Origin header is rarely set when requests are made to the same origin.

This is useful in the cases where cors-anywhere is hosted on a virtual directory (`https://www.example.com/cors-anywhere`) and is used in an app also on a virtual directory on the same host (`https://example.com/app`).

See my comment on #143 for details on why this is needed.

Here is a copy/paste of the relevant information for this pull request :
>If your app is hosted in a virtual directory on the same server (in your case, on `http://localhost:8080/app`). Browsers generally don't put the Origin header since the host is the same. However, they still set the Referer header, though not all in the same way.
> 
> Here are 3 cases for headers for an app located at `http://localhost:8080/app`:
> 
> * Origin (if it was set): `http://localhost:8080`
> * Referer (Chrome): `http://localhost:8080/`
> * Referer (Edge): `http://localhost:8080/app`
> 
> As you can see, Chrome and Edge have a different way of setting the Referer header and both are not the same as what the Origin header would be.
> 
> You would have to replace the line `var origin = req.headers.origin || '';` with the following lines in the file `lib\cors-anywhere.js` :
> 
> ```
> var origin = req.headers.origin || req.headers.referer || '';
> origin = origin.replace(/^(https?:\/\/[^\/]*)(\/.*)?$/, '$1'); // Only keep the host part of the origin/referer
> ```
> Those lines make cors-anywhere take the referer is the origin is not set. It then strips everything but the host part (what the Origin header would be) by using a regex.
> 
> Since you are now looking for a Referer header, you would also need to add `'referer'` to the `requireHeader` array of the `server.js` file.

Note that I was having some trouble with the code coverage not running locally (probably because I am using Windows...).

Also, there is a test that was already failing before I made any changes : `Basic functionality POST file`, maybe also caused by me running Windows.

I will fix problems once Coveralls is done running if there are any.