### PR TITLE
Fix working with single slash in scheme

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -222,11 +222,11 @@ function onProxyResponse(proxy, proxyReq, proxyRes, req, res) {
  * @return {object} URL parsed using url.parse
  */
 function parseURL(req_url) {
-  var match = req_url.match(/^(?:(https?:)?\/\/)?(([^\/?]+?)(?::(\d{0,5})(?=[\/?]|$))?)([\/?][\S\s]*|$)/i);
-  //                              ^^^^^^^          ^^^^^^^^      ^^^^^^^                ^^^^^^^^^^^^
-  //                            1:protocol       3:hostname     4:port                 5:path + query string
-  //                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  //                                            2:host
+  var match = req_url.match(/^(?:(https?:)?\/(\/)?)?(([^\/?]+?)(?::(\d{0,5})(?=[\/?]|$))?)([\/?][\S\s]*|$)/i);
+  //                              ^^^^^^^     ^^      ^^^^^^^^      ^^^^^^^                ^^^^^^^^^^^^
+  //                            1:protocol   2:/    4:hostname     5:port                 6:path + query string
+  //                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  //                                               3:host
   if (!match) {
     return null;
   }
@@ -236,10 +236,14 @@ function parseURL(req_url) {
       // "//" is omitted.
       req_url = '//' + req_url;
     }
-    req_url = (match[4] === '443' ? 'https:' : 'http:') + req_url;
+    req_url = (match[5] === '443' ? 'https:' : 'http:') + req_url;
+  } else if (!match[2]) {
+    // There is scheme but with single / instead of two //
+    req_url = req_url.replace(match[1] + '/', match[1] + '//');
   }
   return url.parse(req_url);
 }
+
 
 // Request handler factory
 function getHandler(options, proxy) {


### PR DESCRIPTION
I've found that some proxy routers like nginx's `proxy_pass` replaces two slashes // to one / in url.

So, address like `cors.myapp.com/https://google.com`
becomes `cors.myapp.com/https:/google.com` and emits error

Have changed a code a little bit to handle these cases if needed.