### PR TITLE
optionally allow credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ proxy requests. The following options are supported:
   Example: `["cookie"]`
 * dictionary of lowercase strings `setHeaders` - Set headers for the request (overwrites existing ones).  
   Example: `{"x-powered-by": "CORS Anywhere"}`
+* boolean `allowCredentials` - Allows proxying of credentials by enabling cookies and setting x-access-control-allow-credentials to 'true'
 * number `corsMaxAge` - If set, an Access-Control-Max-Age request header with this value (in seconds) will be added.  
   Example: `600` - Allow CORS preflight request to be cached by the browser for 10 minutes.
 * string `helpFile` - Set the help file (shown at the homepage).  

--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -65,6 +65,11 @@ function withCORS(headers, request) {
     delete request.headers['access-control-request-headers'];
   }
 
+  if (typeof(request.corsAnywhereRequestState.allowCredentials) !== 'undefined' && request.corsAnywhereRequestState.allowCredentials === true) {
+    headers['access-control-allow-origin'] = request.headers['origin'];
+    headers['access-control-allow-credentials'] = 'true';
+  }
+
   headers['access-control-expose-headers'] = Object.keys(headers).join(',');
 
   return headers;
@@ -131,11 +136,7 @@ function proxyRequest(req, res, proxy) {
   }
 
   // Start proxying the request
-  try {
-    proxy.web(req, res, proxyOptions);
-  } catch (err) {
-    proxy.emit('error', err, req, res);
-  }
+  proxy.web(req, res, proxyOptions);
 }
 
 /**
@@ -208,8 +209,10 @@ function onProxyResponse(proxy, proxyReq, proxyRes, req, res) {
   }
 
   // Strip cookies
-  delete proxyRes.headers['set-cookie'];
-  delete proxyRes.headers['set-cookie2'];
+  if (!(typeof(requestState.allowCredentials) !== 'undefined' && requestState.allowCredentials === true)) {
+    delete proxyRes.headers['set-cookie'];
+    delete proxyRes.headers['set-cookie2'];
+  }
 
   proxyRes.headers['x-final-url'] = requestState.location.href;
   withCORS(proxyRes.headers, req);
@@ -254,6 +257,7 @@ function getHandler(options, proxy) {
     removeHeaders: [],              // Strip these request headers.
     setHeaders: {},                 // Set these request headers.
     corsMaxAge: 0,                  // If set, an Access-Control-Max-Age header with this value (in seconds) will be added.
+    allowCredentials: false,        // Allows proxying of credentials by enabling cookies and setting x-access-control-allow-credentials to 'true'
     helpFile: __dirname + '/help.txt',
   };
 
@@ -286,6 +290,7 @@ function getHandler(options, proxy) {
       getProxyForUrl: corsAnywhere.getProxyForUrl,
       maxRedirects: corsAnywhere.maxRedirects,
       corsMaxAge: corsAnywhere.corsMaxAge,
+      allowCredentials: corsAnywhere.allowCredentials
     };
 
     var cors_headers = withCORS({}, req);
@@ -374,6 +379,7 @@ function getHandler(options, proxy) {
     Object.keys(corsAnywhere.setHeaders).forEach(function(header) {
       req.headers[header] = corsAnywhere.setHeaders[header];
     });
+
 
     req.corsAnywhereRequestState.location = location;
     req.corsAnywhereRequestState.proxyBaseUrl = proxyBaseUrl;


### PR DESCRIPTION
introduce a new flag 'allowCredentials'  disabling the stripping of cookies and set the access-control-allow-credentials header to true. Additionally set the allow-origin header to the explicit origin then as it is required