### PR TITLE
Add possibility to permit specified targets only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts-alpine
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY package.json server.js /app/
+COPY lib /app/lib/
+RUN npm install
+
+ENV CORSANYWHERE_TARGET_WHITELIST "^https?:\/\/duckduckgo\.com"
+
+CMD [ "node", "/app/server.js" ]
+EXPOSE 8080

--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -250,6 +250,7 @@ function getHandler(options, proxy) {
     originWhitelist: [],            // If non-empty, requests not from an origin in this list will be blocked.
     checkRateLimit: null,           // Function that may enforce a rate-limit by returning a non-empty string.
     redirectSameOrigin: false,      // Redirect the client to the requested URL for same-origin requests.
+    checkTargetWhitelisted: null,
     requireHeader: null,            // Require a header to be set?
     removeHeaders: [],              // Strip these request headers.
     setHeaders: {},                 // Set these request headers.
@@ -361,6 +362,12 @@ function getHandler(options, proxy) {
       cors_headers.location = location.href;
       res.writeHead(301, 'Please use a direct request', cors_headers);
       res.end();
+      return;
+    }
+
+    if (corsAnywhere.checkTargetWhitelisted && !corsAnywhere.checkTargetWhitelisted(location)) {
+      res.writeHead(403, 'Forbidden', cors_headers);
+      res.end('You are not permitted to access the location "' + location.href + '".');
       return;
     }
 

--- a/lib/target-whitelist.js
+++ b/lib/target-whitelist.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = function createTargetWhitelistChecker(targetWhitelist) {
+  // Configure targets to access. Use the environment variable CORSANYWHERE_TARGET_WHITELIST with a regular expression.
+  //
+  // Example:
+  // ^https?:\/\/duckduckgo\.com
+  // To access https://duckduckgo.com and all its sub-paths (such as https://duckduckgo.com/?q=looking+for+node.js+proxy)
+  if (!targetWhitelist || targetWhitelist.length === 0) {
+    // Permitted by default
+    return function permitted() {
+      return true;
+    };
+  }
+
+  // Test if regular expression is valid
+  var targetWhitelistPattern = new RegExp(targetWhitelist);
+
+  return function permitted(origin) {
+    if (targetWhitelistPattern && targetWhitelistPattern.test(origin.href)) {
+      return true;
+    }
+
+    return false;
+  };
+};

--- a/server.js
+++ b/server.js
@@ -19,12 +19,16 @@ function parseEnvList(env) {
 // Set up rate-limiting to avoid abuse of the public CORS Anywhere server.
 var checkRateLimit = require('./lib/rate-limit')(process.env.CORSANYWHERE_RATELIMIT);
 
+// Regular expression, which targets are allowed to access
+var checkTargetWhitelisted = require('./lib/target-whitelist')(process.env.CORSANYWHERE_TARGET_WHITELIST);
+
 var cors_proxy = require('./lib/cors-anywhere');
 cors_proxy.createServer({
   originBlacklist: originBlacklist,
   originWhitelist: originWhitelist,
   requireHeader: ['origin', 'x-requested-with'],
   checkRateLimit: checkRateLimit,
+  checkTargetWhitelisted: checkTargetWhitelisted,
   removeHeaders: [
     'cookie',
     'cookie2',


### PR DESCRIPTION
Maybe the project should be named _cors-somewhere_ then, but it can be used in production environment without the risk of having a proxy to sites I do not permit.