### PR TITLE
Add http status mocking feature

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -215,6 +215,11 @@ function onProxyResponse(proxy, proxyReq, proxyRes, req, res) {
   delete proxyRes.headers['set-cookie2'];
 
   proxyRes.headers['x-final-url'] = requestState.location.href;
+
+  if (req.headers['mock-http-response-code']) {
+    proxyRes.statusCode = parseInt(req.headers['mock-http-response-code']);
+  }
+
   withCORS(proxyRes.headers, req);
   return true;
 }
@@ -304,6 +309,7 @@ function getHandler(options, proxy) {
     if (req.method === 'OPTIONS') {
       // Pre-flight request. Reply successfully:
       res.writeHead(200, cors_headers);
+      console.log('ici');
       res.end();
       return;
     }

--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -309,7 +309,6 @@ function getHandler(options, proxy) {
     if (req.method === 'OPTIONS') {
       // Pre-flight request. Reply successfully:
       res.writeHead(200, cors_headers);
-      console.log('ici');
       res.end();
       return;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -344,6 +344,13 @@ describe('Basic functionality', function() {
       .expectNoHeader('set-cookie')
       .expectNoHeader('set-cookie2', done);
   });
+
+  it('Mock a http status response if requested in the headers', function (done) {
+    request(cors_anywhere)
+      .get('/example.com/mockhttpstatus')
+      .set('mock-http-response-code', '200')
+      .expect(200, '', done);
+  });
 });
 
 describe('Proxy errors', function() {


### PR DESCRIPTION
Hi,

I need to mock the HTTP status response for using an external API in Zapier for a customer.

For example, I need to check on this external API if a customer exists in the CRM or not.
If it exists, I do something in Zapier and if not, I do something else.

But when the customer doesn't exist, the API return a 404 error (which is normal) but Zapier interpret is an error, stops the workflow and send an email error to my customer.

So by adding a feature where you can mock the HTTP response status to the one that you choose (200), it works now 😎

How I solve it : 
If you pass an external header 'mock-http-response-code' and the status code that you want, it will respond with the mocked status code that I added in the response.

I fork it and use it on my heroku server but I don't know if you want to integrate this feature also ?
I added a test but it still fails :( 

Thanks!