### PR TITLE
Add url as querystring

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Request examples:
 
 * `http://localhost:8080/http://google.com/` - Google.com with CORS headers
 * `http://localhost:8080/google.com` - Same as previous.
+* `http://localhost:8080/?url=http://google.com` - Same as previous using url param.
 * `http://localhost:8080/google.com:443` - Proxies `https://google.com/`
 * `http://localhost:8080/` - Shows usage text, as defined in `libs/help.txt`
 * `http://localhost:8080/favicon.ico` - Replies 404 Not found

--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -225,6 +225,7 @@ function onProxyResponse(proxy, proxyReq, proxyRes, req, res) {
  * @return {object} URL parsed using url.parse
  */
 function parseURL(req_url) {
+  req_url = req_url.replace(/^\?url=/, '');
   var match = req_url.match(/^(?:(https?:)?\/\/)?(([^\/?]+?)(?::(\d{0,5})(?=[\/?]|$))?)([\/?][\S\s]*|$)/i);
   //                              ^^^^^^^          ^^^^^^^^      ^^^^^^^                ^^^^^^^^^^^^
   //                            1:protocol       3:hostname     4:port                 5:path + query string

--- a/test/test-examples.js
+++ b/test/test-examples.js
@@ -49,6 +49,26 @@ describe('Examples', function() {
       .expect(200, 'Response from example.com', done);
   });
 
+  it('Rewrite proxy URL with url as param', function(done) {
+    var cors_anywhere = createServer();
+
+    var http_server = http.createServer(function(req, res) {
+      // For testing, check whether req.url is the same as what we input below.
+      assert.strictEqual(req.url, '/dummy-for-testing');
+
+      // Basic example: Always proxy example.com.
+      req.url = '/?url=http://example.com';
+
+      cors_anywhere.emit('request', req, res);
+    });
+
+    request(http_server)
+      .get('/dummy-for-testing')
+      .expect('Access-Control-Allow-Origin', '*')
+      .expect('x-request-url', 'http://example.com/')
+      .expect(200, 'Response from example.com', done);
+  });
+
   it('Transform response to uppercase (streaming)', function(done) {
     var cors_anywhere = createServer();
 


### PR DESCRIPTION
This PR allow you to pass the url as querystring also.
In this way:

http://localhost:8080/?url=http://google.com

Why this PR?
I had some problems putting it behind an Apache proxy. The url was not passed. Maybe I was wrong. But in my opinion it is useful to have this possibility too.