### PR TITLE
Adding set params option

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -265,6 +265,7 @@ function getHandler(options, proxy) {
     requireHeader: null,            // Require a header to be set?
     removeHeaders: [],              // Strip these request headers.
     setHeaders: {},                 // Set these request headers.
+    setParams:{},                   // Set request params
     corsMaxAge: 0,                  // If set, an Access-Control-Max-Age header with this value (in seconds) will be added.
     helpFile: __dirname + '/help.txt',
   };
@@ -306,6 +307,13 @@ function getHandler(options, proxy) {
       res.writeHead(200, cors_headers);
       res.end();
       return;
+    }
+
+    // set Params on url
+    var params = Object.entries(corsAnywhere.setParams).map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&')
+    if (params){
+      req.url = req.url + (req.url.indexOf("?") == -1 ? '?' :'&')
+      req.url = req.url+params
     }
 
     var location = parseURL(req.url.slice(1));

--- a/test/test.js
+++ b/test/test.js
@@ -892,6 +892,25 @@ describe('setHeaders', function() {
   });
 });
 
+describe('setParams', function() {
+  before(function() {
+    cors_anywhere = createServer({
+      setParams: {test: '123'},
+    });
+    cors_anywhere_port = cors_anywhere.listen(0).address().port;
+  });
+  after(stopServer);
+
+  it('GET /example.com', function(done) {
+    request(cors_anywhere)
+    .get('/example.com')
+    .expect('Access-Control-Allow-Origin', '*')
+    .expect(200, 'Response from example.com', done);
+  });
+
+});
+
+
 describe('setHeaders + removeHeaders', function() {
   before(function() {
     // setHeaders takes precedence over removeHeaders


### PR DESCRIPTION
This provides an additional option to inject params into the request at server level. Useful for injecting API keys which you may not want to expose on client side.