### PR TITLE
add focal to travis to catch errors on newer linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ node_js:
   - 13
   - 13
   - 14
+jobs:
+  include:
+    - os: linux
+      dist: xenial
+    - os: linux
+      dist: focal
 script:
   - npm run lint
   - npm run test


### PR DESCRIPTION
to catch bugs like Error:SSL routines:SSL_CTX_use_certificate:ee key too small

https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1