### PR TITLE
only send Access-Control-Max-Age if preflight request, not POST/GET

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -53,7 +53,7 @@ function isValidHostName(hostname) {
 function withCORS(headers, request) {
   headers['access-control-allow-origin'] = '*';
   var corsMaxAge = request.corsAnywhereRequestState.corsMaxAge;
-  if (corsMaxAge) {
+  if (request.method === 'OPTIONS' && corsMaxAge) {
     headers['access-control-max-age'] = corsMaxAge;
   }
   if (request.headers['access-control-request-method']) {


### PR DESCRIPTION
-Access-Control-Max-Age header only has meaning for preflights, not
 POST or GET, saves wire bytes by excluding it from POST/GET/etc