### PR TITLE
remove Heroku specific Req headers from being sent to Origin

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,6 +33,14 @@ cors_proxy.createServer({
     'x-heroku-queue-depth',
     'x-heroku-dynos-in-use',
     'x-request-start',
+    'x-request-id',
+    'via',
+    'connect-time',
+    'total-route-time',
+    // Other Heroku added debug headers
+    // 'x-forwarded-for',
+    // 'x-forwarded-proto',
+    // 'x-forwarded-port',
   ],
   redirectSameOrigin: true,
   httpProxyOptions: {


### PR DESCRIPTION
-saves bytes, and avoids triggering IDS/WAF alarms since browser finger
 printing will prove these headers are unnatural and on SSL must be a MITM
 attack