### PR TITLE
Fix for "Access-Control-Allow-Credentials" is "true"

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -65,6 +65,11 @@ function withCORS(headers, request) {
     delete request.headers['access-control-request-headers'];
   }
 
+  //If "Access-Control-Allow-Credentials" is "true", "Access-Control-Allow-Origin" cannot be "*"!
+  //https://github.com/Rob--W/cors-anywhere/issues/330
+  if (headers['access-control-allow-credentials']) {
+    headers['access-control-allow-origin'] = request.headers['origin'];
+  }
   headers['access-control-expose-headers'] = Object.keys(headers).join(',');
 
   return headers;


### PR DESCRIPTION
cors-anywhere does not work if credentials are passed in the requested:
If "Access-Control-Allow-Credentials" is "true" --> "Access-Control-Allow-Origin" cannot be "*"


https://github.com/Rob--W/cors-anywhere/issues/330