### PR TITLE
Add remove headers

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -384,7 +384,8 @@ function getHandler(options, proxy) {
     var isRequestedOverHttps = req.connection.encrypted || /^\s*https/.test(req.headers['x-forwarded-proto']);
     var proxyBaseUrl = (isRequestedOverHttps ? 'https://' : 'http://') + req.headers.host;
 
-    corsAnywhere.removeHeaders.forEach(function(header) {
+    const removeHeaders = req.headers['Remove-Headers'] ? req.headers['Remove-Headers'].split(',') : [];
+    [...corsAnywhere.removeHeaders, ...removeHeaders].forEach(function(header) {
       delete req.headers[header];
     });
 


### PR DESCRIPTION
Users can now use `Remove-Headers: User-Agent, Test`, so the proxy can be used for different websites (for some websites I needed to keep it, and for others I needed to let it)