### PR TITLE
add workaround to URL parser for Cloudflare Reverse Proxy bug

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -225,6 +225,21 @@ function onProxyResponse(proxy, proxyReq, proxyRes, req, res) {
  * @return {object} URL parsed using url.parse
  */
 function parseURL(req_url) {
+  //Cloudflare reverse proxy has a bug of collapsing multiple /s to one
+  // https://community.cloudflare.com/t/worker-url-obj-parses-double-backslash-diff-from-chrome/210046
+  // https://community.cloudflare.com/t/bug-inconsistent-url-behaviour/98044
+  // https://community.cloudflare.com/t/worker-fetch-mangles-location-header-url-on-redirect-from-origin/311984
+  //so just make https://fooapp.herokuapp.com/http:/example.com/index.html
+  //parse correctly
+
+  //handling a corrupted good URL such as
+  //https://fooapp.herokuapp.com///example.com/index.html
+  //which corrupts to
+  //https://fooapp.herokuapp.com//example.com/index.html is skipped
+  //since its a much more rare URL format and unknown if it was really
+  //a corrupt protocol relative or a true server relative
+  //(unsupported, this is a proxy, we don't have endpoints or content)
+  req_url = req_url.replace(/^http(s?):\/(?!\/)/, 'http$1://');
   var match = req_url.match(/^(?:(https?:)?\/\/)?(([^\/?]+?)(?::(\d{0,5})(?=[\/?]|$))?)([\/?][\S\s]*|$)/i);
   //                              ^^^^^^^          ^^^^^^^^      ^^^^^^^                ^^^^^^^^^^^^
   //                            1:protocol       3:hostname     4:port                 5:path + query string


### PR DESCRIPTION
Read commit comments. A Cors-anywhere instance behind Cloudflare's WAF/reverse proxy, is unusable because of the "//" to "/" bug that is all over CF's technology. Why someone would use cors-anywhere on node on aws, instead of writing a Cloudflare Worker to do the same thing, when they are a cloudflare customer, is a different story. Without this patch, cors-anywhere sometimes bizarrely shows the "showUsage" page when behind Cloudflare, but works perfect connecting to AWS or localhost directly from chrome. Even if this patch isn't accepted, its a warning that CA has major problems behind CFs WAF.