### PR TITLE
Add cli script for bin

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+const { program } = require('commander');
+program
+  .option('-p, --port <port>', 'port')
+  .option('-h, --host <host>', 'host');
+
+program.parse(process.argv);
+const options = program.opts();
+
+if (options.port !== undefined) {
+  process.env.PORT = parseInt(options.port);
+}
+if (options.host !== undefined) {
+  process.env.HOST = parseInt(options.host);
+}
+require('./server');

--- a/package.json
+++ b/package.json
@@ -27,7 +27,11 @@
     "demo.html",
     "server.js"
   ],
+  "bin": {
+    "cors-anywhere": "./cli.js"
+  },
   "dependencies": {
+    "commander": "8.3.0",
     "http-proxy": "1.11.1",
     "proxy-from-env": "0.0.1"
   },


### PR DESCRIPTION
Adds cli script and exposes it as the package binary. Supports `-p` `--port` flag for choosing port and `-h` `--host` flag for choosing host.

related #104 and #35