### PR TITLE
Update http-proxy to 1.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "server.js"
   ],
   "dependencies": {
-    "http-proxy": "1.11.1",
+    "http-proxy": "1.18.1",
     "proxy-from-env": "0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`http-proxy 1.18.1` contains the fix for the denial of service attack issue with the `setHeader` function.

Fix https://github.com/Rob--W/cors-anywhere/issues/402