### PR TITLE
Update http-proxy dep version to 1.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "server.js"
   ],
   "dependencies": {
-    "http-proxy": "1.11.1",
+    "http-proxy": "1.18.1",
     "proxy-from-env": "0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Received a warning in npm that there is high security vulnerability of ddos in the old version, and it's fixed in 1.18.1.