### PR TITLE
a quick demo/example

### DIFF
--- a/lib/example.js
+++ b/lib/example.js
@@ -1,0 +1,12 @@
+// Listen on a specific host via the HOST environment variable
+var host = process.env.HOST || '127.0.0.1';
+// Listen on a specific port via the PORT environment variable
+var port = process.env.PORT || 8080;
+
+var cors_proxy = require('./cors-anywhere.js');
+cors_proxy.createServer({
+    originWhitelist: [], // Allow all origins
+    removeHeaders: ['cookie', 'cookie2']
+}).listen(port, host, function() {
+    console.log('Running CORS Anywhere on ' + host + ':' + port);
+});

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint": "eslint .",
     "test": "mocha ./test/test*.js --reporter spec",
     "test-coverage": "istanbul cover ./node_modules/.bin/_mocha -- test/test.js test/test-ratelimit.js --reporter spec",
-	"example": "node ./lib/example.js"
+    "example": "node ./lib/example.js"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha ./test/test*.js --reporter spec",
-    "test-coverage": "istanbul cover ./node_modules/.bin/_mocha -- test/test.js test/test-ratelimit.js --reporter spec"
+    "test-coverage": "istanbul cover ./node_modules/.bin/_mocha -- test/test.js test/test-ratelimit.js --reporter spec",
+	"example": "node ./lib/example.js"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
So, without creating files manually and trying to setup the proxy, the command:
`npm run example`
will quickly spin up the local server, so easier for newbies.