### PR TITLE
Add a vercel.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 coverage/
 node_modules/
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "server.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/server.js"
+    }
+  ]
+}


### PR DESCRIPTION
This allows automated deployment of Vercel project from this repo.

With Heroku stopping their free service on November 28th, this change provides a path to Vercel deployment as an alternative.