### PR TITLE
Add "start" script in order to work with cloud apps directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "supertest": "^2.0.1"
   },
   "scripts": {
+    "start": "node server.js",
     "lint": "eslint .",
     "test": "mocha ./test/test*.js --reporter spec",
     "test-coverage": "istanbul cover ./node_modules/.bin/_mocha -- test/test.js test/test-ratelimit.js --reporter spec"


### PR DESCRIPTION
The current package.json does not have a "start" script which is required for example Azure webapps configuration to work automatically. With this change it is possible to deploy proxy out-of-the-box to Azure. I cannot see any downsides of this modification.