### PR TITLE
add the fuctionality for blocking the proxying to spefic urls

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -5,6 +5,7 @@
 
 var httpProxy = require('http-proxy');
 var net = require('net');
+const { parse } = require('path');
 var url = require('url');
 var regexp_tld = require('./regexp-top-level-domain');
 var getProxyForUrl = require('proxy-from-env').getProxyForUrl;
@@ -253,12 +254,32 @@ function parseURL(req_url) {
   return parsed;
 }
 
+
+function checkUrlMatchList(url,list){
+  var parsed_list=list.map((el)=> parseURL(el))
+  
+  var complete_url=url.host+url.pathname
+  
+  for (var i in parsed_list){
+    var url = parsed_list[i].host +parsed_list[i].pathname
+    url=url.replace(".","\.")
+    url=url.replace("*","[^.]*")
+    var regrex= RegExp("^"+url+"$")
+    if (regrex.test(complete_url)){
+      return true
+    }
+  }
+  return false 
+}
+
 // Request handler factory
 function getHandler(options, proxy) {
   var corsAnywhere = {
     handleInitialRequest: null,     // Function that may handle the request instead, by returning a truthy value.
     getProxyForUrl: getProxyForUrl, // Function that specifies the proxy to use
     maxRedirects: 5,                // Maximum number of redirects to be followed.
+    requestUrlBlacklist: [],        // Requests to these url will be blocked.
+    requestUrlWhitelist: [],        // If non-empty, requests not from an url in this list will be blocked.
     originBlacklist: [],            // Requests from these origins will be blocked.
     originWhitelist: [],            // If non-empty, requests not from an origin in this list will be blocked.
     checkRateLimit: null,           // Function that may enforce a rate-limit by returning a non-empty string.
@@ -357,6 +378,23 @@ function getHandler(options, proxy) {
       res.end('Missing required request header. Must specify one of: ' + corsAnywhere.requireHeader);
       return;
     }
+
+    if (corsAnywhere.requestUrlBlacklist.length>0){
+      if (checkUrlMatchList(location,corsAnywhere.requestUrlBlacklist)){
+        res.writeHead(403, 'Forbidden', cors_headers);
+        res.end('The destination "' + req.url.slice(1) + '" was blocked by the operator of this proxy.');
+        return ;
+      }
+    }
+
+    if (corsAnywhere.requestUrlWhitelist.length>0){
+      if (! checkUrlMatchList(location,corsAnywhere.requestUrlWhitelist)){
+        res.writeHead(403, 'Forbidden', cors_headers);
+        res.end('The destination "' + req.url.slice(1) + '" was blocked by the operator of this proxy.');
+        return;
+      }
+    }
+
 
     var origin = req.headers.origin || '';
     if (corsAnywhere.originBlacklist.indexOf(origin) >= 0) {

--- a/server.js
+++ b/server.js
@@ -9,6 +9,9 @@ var port = process.env.PORT || 8080;
 // use originWhitelist instead.
 var originBlacklist = parseEnvList(process.env.CORSANYWHERE_BLACKLIST);
 var originWhitelist = parseEnvList(process.env.CORSANYWHERE_WHITELIST);
+var requestUrlBlacklist= parseEnvList(process.env.CORSANYWHERE_URL_BLACKLIST);
+var requestUrlWhitelist = parseEnvList(process.env.CORSANYWHERE_URL_WHITELIST);
+
 function parseEnvList(env) {
   if (!env) {
     return [];
@@ -23,6 +26,8 @@ var cors_proxy = require('./lib/cors-anywhere');
 cors_proxy.createServer({
   originBlacklist: originBlacklist,
   originWhitelist: originWhitelist,
+  requestUrlBlacklist:requestUrlBlacklist,
+  requestUrlWhitelist:requestUrlWhitelist,
   requireHeader: ['origin', 'x-requested-with'],
   checkRateLimit: checkRateLimit,
   removeHeaders: [


### PR DESCRIPTION
I added the functinality for blocking request to specific urls.
so all the request to urls in the list requestUrlBlacklist will blocked
and all the urls not in the list requestUrlWhitelist will be blocked.

examples:
you want a proxy that allow access to "google.com" and deny to all other request
requestUrlWhitelist : ["google.com/*"]

you want a proxy that deny access to "google.com" and allow to all other request
requestUrlBlacklist: ["google.com/*"]

you want a proxy that allow access to google.com from a specif path "test" and deny to all other request
requestUrlWhitelist : ["google.com/test/*"]
google.com/test/blabla ->access granted
google.com/hello/ -> access denied
google.com/ -> access denied
