### PR TITLE
Support whitelisting specific cookies

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -50,8 +50,13 @@ function isValidHostName(hostname) {
  * @param headers {object} Response headers
  * @param request {ServerRequest}
  */
-function withCORS(headers, request) {
-  headers['access-control-allow-origin'] = '*';
+function withCORS(headers, request, corsAnywhere) {
+  if (corsAnywhere.allowCookies.length && corsAnywhere.originWhitelist.includes(request.headers.origin)) {
+    headers['access-control-allow-origin'] = request.headers.origin;
+    headers['access-control-allow-credentials'] = 'true';
+  } else {
+    headers['access-control-allow-origin'] = '*';
+  }
   var corsMaxAge = request.corsAnywhereRequestState.corsMaxAge;
   if (request.method === 'OPTIONS' && corsMaxAge) {
     headers['access-control-max-age'] = corsMaxAge;
@@ -227,7 +232,7 @@ function onProxyResponse(proxy, proxyReq, proxyRes, req, res, corsAnywhere) {
   }
 
   proxyRes.headers['x-final-url'] = requestState.location.href;
-  withCORS(proxyRes.headers, req);
+  withCORS(proxyRes.headers, req, corsAnywhere);
   return true;
 }
 
@@ -277,7 +282,7 @@ function getHandler(options, proxy) {
     redirectSameOrigin: false,      // Redirect the client to the requested URL for same-origin requests.
     requireHeader: null,            // Require a header to be set?
     removeHeaders: [],              // Strip these request headers.
-    allowCookies: [],               // Allow these cookies.
+    allowCookies: [],               // Allow these cookies. If originWhitelist is non-empty these domains will also be sent Access-Control-Allow-Credentials: true.
     setHeaders: {},                 // Set these request headers.
     corsMaxAge: 0,                  // If set, an Access-Control-Max-Age header with this value (in seconds) will be added.
     helpFile: __dirname + '/help.txt',
@@ -314,7 +319,7 @@ function getHandler(options, proxy) {
       corsMaxAge: corsAnywhere.corsMaxAge,
     };
 
-    var cors_headers = withCORS({}, req);
+    var cors_headers = withCORS({}, req, corsAnywhere);
     if (req.method === 'OPTIONS') {
       // Pre-flight request. Reply successfully:
       res.writeHead(200, cors_headers);

--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -77,7 +77,7 @@ function withCORS(headers, request) {
  * @param res {ServerResponse} Outgoing (proxied) http request
  * @param proxy {HttpProxy}
  */
-function proxyRequest(req, res, proxy) {
+function proxyRequest(req, res, proxy, corsAnywhere) {
   var location = req.corsAnywhereRequestState.location;
   req.url = location.path;
 
@@ -100,7 +100,7 @@ function proxyRequest(req, res, proxy) {
             return proxyReqOn.call(this, eventName, listener);
           }
           return proxyReqOn.call(this, 'response', function(proxyRes) {
-            if (onProxyResponse(proxy, proxyReq, proxyRes, req, res)) {
+            if (onProxyResponse(proxy, proxyReq, proxyRes, req, res, corsAnywhere)) {
               try {
                 listener(proxyRes);
               } catch (err) {
@@ -160,7 +160,7 @@ function proxyRequest(req, res, proxy) {
  *
  * @returns {boolean} true if http-proxy should continue to pipe proxyRes to res.
  */
-function onProxyResponse(proxy, proxyReq, proxyRes, req, res) {
+function onProxyResponse(proxy, proxyReq, proxyRes, req, res, corsAnywhere) {
   var requestState = req.corsAnywhereRequestState;
 
   var statusCode = proxyRes.statusCode;
@@ -202,7 +202,7 @@ function onProxyResponse(proxy, proxyReq, proxyRes, req, res) {
           proxyReq.abort();
 
           // Initiate a new proxy request.
-          proxyRequest(req, res, proxy);
+          proxyRequest(req, res, proxy, corsAnywhere);
           return false;
         }
       }
@@ -210,9 +210,21 @@ function onProxyResponse(proxy, proxyReq, proxyRes, req, res) {
     }
   }
 
-  // Strip cookies
-  delete proxyRes.headers['set-cookie'];
-  delete proxyRes.headers['set-cookie2'];
+  // Fudge cookies
+  for (let cheader of ['set-cookie', 'set-cookie2']) {
+    let cookies = proxyRes.headers[cheader] || [];
+    for (let i = cookies.length - 1; i >= 0; i--) {
+      let cookie = cookies[i];
+      let cname = cookie.split('=')[0];
+      if (corsAnywhere.allowCookies.includes(cname)) {
+        // strip domain so browser doesn't ignore it
+        cookies[i] = cookie.replace(/domain=[^;]*;\s?/ig, "");
+      } else {
+        // delete it
+        cookies.splice(i, 1);
+      }
+    }
+  }
 
   proxyRes.headers['x-final-url'] = requestState.location.href;
   withCORS(proxyRes.headers, req);
@@ -265,6 +277,7 @@ function getHandler(options, proxy) {
     redirectSameOrigin: false,      // Redirect the client to the requested URL for same-origin requests.
     requireHeader: null,            // Require a header to be set?
     removeHeaders: [],              // Strip these request headers.
+    allowCookies: [],               // Allow these cookies.
     setHeaders: {},                 // Set these request headers.
     corsMaxAge: 0,                  // If set, an Access-Control-Max-Age header with this value (in seconds) will be added.
     helpFile: __dirname + '/help.txt',
@@ -392,6 +405,20 @@ function getHandler(options, proxy) {
     var isRequestedOverHttps = req.connection.encrypted || /^\s*https/.test(req.headers['x-forwarded-proto']);
     var proxyBaseUrl = (isRequestedOverHttps ? 'https://' : 'http://') + req.headers.host;
 
+    let cookies = req.headers['cookie'] || "";
+    cookies = cookies.split(/;\s/g);
+    for (let i = cookies.length - 1; i >= 0; i--) {
+      let cookie = cookies[i];
+      let cname = cookie.split('=')[0];
+      if (!corsAnywhere.allowCookies.includes(cname)) {
+        cookies.splice(i, 1);
+      }
+    }
+    delete req.headers['cookie'];
+    if (cookies.length) {
+      req.headers['cookie'] = cookies.join('; ');
+    }
+
     corsAnywhere.removeHeaders.forEach(function(header) {
       delete req.headers[header];
     });
@@ -403,7 +430,7 @@ function getHandler(options, proxy) {
     req.corsAnywhereRequestState.location = location;
     req.corsAnywhereRequestState.proxyBaseUrl = proxyBaseUrl;
 
-    proxyRequest(req, res, proxy);
+    proxyRequest(req, res, proxy, corsAnywhere);
   };
 }
 


### PR DESCRIPTION
Some public websites use cookies for non-secure stuff like:

- setting UI options such as mobile
- setting some anonymous ID to help fight spam, e.g. fanyi.baidu.com

This PR allows the server operator to whitelist specific cookies used for these purposes.