### PR TITLE
Pass X-Cors-Headers between the client and the remote

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -210,10 +210,17 @@ function onProxyResponse(proxy, proxyReq, proxyRes, req, res) {
     }
   }
 
-  // Strip cookies
-  delete proxyRes.headers['set-cookie'];
-  delete proxyRes.headers['set-cookie2'];
+  let extraHeaders = {}
 
+  // Strip cookies
+  for (let k of ['set-cookie', 'set-cookie2']) {
+    if (k in proxyRes.headers) {
+      extraHeaders[k] = proxyRes.headers[k];
+      delete proxyRes.headers[k];
+    }
+  }
+
+  proxyRes.headers['x-cors-headers'] = JSON.stringify(extraHeaders);
   proxyRes.headers['x-final-url'] = requestState.location.href;
   withCORS(proxyRes.headers, req);
   return true;
@@ -391,6 +398,14 @@ function getHandler(options, proxy) {
 
     var isRequestedOverHttps = req.connection.encrypted || /^\s*https/.test(req.headers['x-forwarded-proto']);
     var proxyBaseUrl = (isRequestedOverHttps ? 'https://' : 'http://') + req.headers.host;
+
+    try {
+        let extraHeaders = JSON.parse(req.headers['x-cors-headers'] || "{}");
+        for (let [k, v] of Object.entries(extraHeaders)) {
+            req.headers[k] = v;
+        }
+        delete req.headers['x-cors-headers'];
+    } catch (e) {}
 
     corsAnywhere.removeHeaders.forEach(function(header) {
       delete req.headers[header];


### PR DESCRIPTION
This is basically what https://github.com/Zibri/cloudflare-cors-anywhere does, except it chooses to use "Cors-Received-Headers" for the incoming headers, which IMO is wrong as it doesn't start with X-.

As mentioned in #469 this is a way for client application code to process cookies of 3rd-party domains without going through the browser's native cookie mechanisms. Then, there is basically no chance of mixing things up as client application code does not have access to 3rd party cookies of other domains (e.g. the ones being proxied) anyway.

The general idea is that the client parses the cookie headers manually and stores them in some place other than the actual browser cookie storage for the site hosting the application, e.g.:

~~~~
    let remoteCookies = [];
    ...

    const resp = await fetch(
      corsProxy + URL,
      ...
    )
    await resp.text();

    let corsHeaders = JSON.parse(resp.headers.get("x-cors-headers") || "{}");
    for (let cookie of corsHeaders["set-cookie"]) {
      cookie = cookie.split(";")[0];
      let cname = cookie.split("=")[0];
      if (ALLOW_COOKIES.includes(cname)) {
        remoteCookies.push(cookie);
      }
    }
    ...

    const resp2 = await fetch(
      corsProxy + URL2,
      {
        headers: {
          "X-Cors-Headers": JSON.stringify({"cookie": remoteCookies.join("; ")}),
          ...
        },
      }
    )
    const body2 = await resp2.text();
~~~~

For simplicity I didn't restrict what can be sent out via X-Cors-Headers but if you prefer to restrict that to Cookie: only, that's also fine of course. (The incoming headers are restricted to Set-Cookie because the other headers are already available via the normal mechanisms.)