### PR TITLE
Adding custom listeners functions to proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ For advanced users, the following options are also provided.
 * `httpProxyOptions` - Under the hood, [http-proxy](https://github.com/nodejitsu/node-http-proxy)
   is used to proxy requests. Use this option if you really need to pass options
   to http-proxy. The documentation for these options can be found [here](https://github.com/nodejitsu/node-http-proxy#options).
+  * `httpProxyOptions.customListeners` - If set, this function is called with the httpProxy instance
+    as argument. This allows you to register custom event listeners, for example to listen for the
+    `proxyReq` event.
 * `httpsOptions` - If set, a `https.Server` will be created. The given options are passed to the
   [`https.createServer`](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) method.
 

--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -433,30 +433,37 @@ exports.createServer = function createServer(options) {
     server = require('http').createServer(requestHandler);
   }
 
-  // When the server fails, just show a 404 instead of Internal server error
-  proxy.on('error', function(err, req, res) {
-    if (res.headersSent) {
-      // This could happen when a protocol error occurs when an error occurs
-      // after the headers have been received (and forwarded). Do not write
-      // the headers because it would generate an error.
-      // Prior to Node 13.x, the stream would have ended.
-      // As of Node 13.x, we must explicitly close it.
-      if (res.writableEnded === false) {
-        res.end();
-      }
-      return;
-    }
-
-    // When the error occurs after setting headers but before writing the response,
-    // then any previously set headers must be removed.
-    var headerNames = res.getHeaderNames ? res.getHeaderNames() : Object.keys(res._headers || {});
-    headerNames.forEach(function(name) {
-      res.removeHeader(name);
+  // Adding custom events listeners to http server passed in options
+  if (httpProxyOptions && httpProxyOptions.customListeners) {
+    Object.keys(httpProxyOptions.customListeners).forEach(function(event) {
+      proxy.on(event, httpProxyOptions.customListeners[event]);
     });
-
-    res.writeHead(404, {'Access-Control-Allow-Origin': '*'});
-    res.end('Not found because of proxy error: ' + err);
-  });
+  } else {
+    // When the server fails, just show a 404 instead of Internal server error
+    proxy.on('error', function(err, req, res) {
+      if (res.headersSent) {
+        // This could happen when a protocol error occurs when an error occurs
+        // after the headers have been received (and forwarded). Do not write
+        // the headers because it would generate an error.
+        // Prior to Node 13.x, the stream would have ended.
+        // As of Node 13.x, we must explicitly close it.
+        if (res.writableEnded === false) {
+          res.end();
+        }
+        return;
+      }
+  
+      // When the error occurs after setting headers but before writing the response,
+      // then any previously set headers must be removed.
+      var headerNames = res.getHeaderNames ? res.getHeaderNames() : Object.keys(res._headers || {});
+      headerNames.forEach(function(name) {
+        res.removeHeader(name);
+      });
+  
+      res.writeHead(404, {'Access-Control-Allow-Origin': '*'});
+      res.end('Not found because of proxy error: ' + err);
+    });
+  }
 
   return server;
 };


### PR DESCRIPTION
If set, this functionsare called with the httpProxy instance as argument. This allows you to register custom event listeners, for example to listen for the `proxyReq` event.