### PR TITLE
Set Allow Credentials Header to True

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -66,6 +66,7 @@ function withCORS(headers, request) {
   }
 
   headers['access-control-expose-headers'] = Object.keys(headers).join(',');
+  headers['access-control-allow-credentials'] = 'true';
 
   return headers;
 }


### PR DESCRIPTION
This fixes [Preflight Request Error](https://stackoverflow.com/questions/43772830/access-control-allow-credentials-header-in-the-response-is-which-must-be-t)